### PR TITLE
Fixed winreg::QueryValueType returning REG_SZ for expand string value

### DIFF
--- a/WinReg/WinReg/WinReg.hpp
+++ b/WinReg/WinReg/WinReg.hpp
@@ -919,21 +919,20 @@ inline std::vector<BYTE> GetBinaryValue(HKEY hKey, const std::wstring& valueName
 // Return the DWORD type ID for the input registry value
 inline DWORD QueryValueType(HKEY hKey, const std::wstring& valueName)
 {
-    DWORD typeId{};     // will be returned by RegGetValue
+    DWORD typeId{};     // will be returned by RegQueryValueEx
 
-    const DWORD flags = RRF_RT_ANY;     // no type restriction
-    LONG retCode = ::RegGetValue(
+    LONG retCode = ::RegQueryValueEx(
         hKey,
-        nullptr, // no subkey
         valueName.c_str(),
-        flags,
+        nullptr,    // reserved
         &typeId,
-        nullptr, // not interested
-        nullptr  // not interested
+        nullptr,    // not interested
+        nullptr     // not interested
     );
+
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ "Cannot get the value type: RegGetValue failed.", retCode };
+        throw RegException{ "Cannot get the value type: RegQueryValueEx failed.", retCode };
     }
 
     return typeId;

--- a/WinReg/WinReg/WinRegTest.cpp
+++ b/WinReg/WinReg/WinRegTest.cpp
@@ -112,9 +112,6 @@ int main()
         typeId = winreg::QueryValueType(key.Get(), L"TestValueExpandString");
         if (typeId != REG_EXPAND_SZ)
         {
-            // NOTE: This seems a bug in the RegGetValue API, *not* in my wrapper function.
-            // In fact, I tried direct RegGetValue calls for REG_EXPAND_SZ values,
-            // and the API returns REG_SZ instead :(
             wcout << "winreg::QueryValueType failed for REG_EXPAND_SZ.\n";
         }
 


### PR DESCRIPTION
I expected winreg::QueryValueType to return REG_EXPAND_SZ for expand
string. Initially I called RegGetValue for querying the type, and it
returned REG_SZ since it auto-expanded the string value. I replace the
call to RegGetValue with RegQueryValueEx, and now it returns
REG_EXPAND_SZ as expected (no auto string expansion).