### PR TITLE
Removed uniform brace initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v2.2.2
+# WinReg v2.2.3
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio
@@ -40,7 +40,7 @@ There are many member functions inside the `RegKey` class, that wrap many parts 
 For example, you can simply open a registry key and get registry values with C++ code like this:
 
 ```c++
-RegKey  key{ HKEY_CURRENT_USER, L"SOFTWARE\\SomeKey" };
+RegKey  key(HKEY_CURRENT_USER, L"SOFTWARE\\SomeKey");
 
 DWORD   dw = key.GetDwordValue (L"SomeDwordValue");
 wstring s  = key.GetStringValue(L"SomeStringValue");

--- a/WinReg/WinReg.hpp
+++ b/WinReg/WinReg.hpp
@@ -9,9 +9,9 @@
 //               Copyright (C) by Giovanni Dicanio
 //
 // First version: 2017, January 22nd
-// Last update:   2020, April 22nd
+// Last update:   2020, April 24th
 //
-// E-mail: <giovanni.dicanio AT REMOVE_THIS gmail.com>
+// E-mail: <first name>.<last name> AT REMOVE_THIS gmail.com
 //
 // Registry key handles are safely and conveniently wrapped
 // in the RegKey resource manager C++ class.
@@ -367,7 +367,7 @@ public:
 
 private:
     // The wrapped registry key handle
-    HKEY m_hKey{ nullptr };
+    HKEY m_hKey = nullptr;
 };
 
 
@@ -378,40 +378,28 @@ class RegResult
 {
 public:
 
+    // Initialize to success code (ERROR_SUCCESS)
     RegResult() noexcept = default;
 
     // Conversion constructor, *not* marked "explicit" on purpose,
     // allows easy and convenient conversion from Win32 API return code type
     // to this C++ wrapper.
-    RegResult(LONG result) noexcept
-        : m_result{ result }
-    {}
+    RegResult(LONG result) noexcept;
 
-    bool IsOk() const noexcept
-    {
-        return m_result == ERROR_SUCCESS;
-    }
+    // Is the wrapped code a success code?
+    bool IsOk() const noexcept;
 
-    bool Failed() const noexcept
-    {
-        return m_result != ERROR_SUCCESS;
-    }
+    // Is the wrapped error code a failure code?
+    bool Failed() const noexcept;
 
-    explicit operator bool() const noexcept
-    {
-        return IsOk();
-    }
+    // Is the wrapped code a success code?
+    explicit operator bool() const noexcept;
 
-    LONG Code() const noexcept
-    {
-        return m_result;
-    }
+    // Get the wrapped Win32 code
+    LONG Code() const noexcept;
 
     // Return the system error message associated to the current error code
-    std::wstring ErrorMessage() const
-    {
-        return ErrorMessage(MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT));
-    }
+    std::wstring ErrorMessage() const;
 
     // Return the system error message associated to the current error code,
     // using the given input language identifier
@@ -420,7 +408,7 @@ public:
 private:
     // Error code returned by Windows Registry C API;
     // default initialized to success code.
-    LONG m_result{ ERROR_SUCCESS };
+    LONG m_result = ERROR_SUCCESS;
 };
 
 
@@ -432,11 +420,11 @@ class RegException
 {
 public:
     RegException(LONG errorCode, const char* message)
-        : std::system_error{ errorCode, std::system_category(), message }
+        : std::system_error(errorCode, std::system_category(), message)
     {}
 
     RegException(LONG errorCode, const std::string& message)
-        : std::system_error{ errorCode, std::system_category(), message }
+        : std::system_error(errorCode, std::system_category(), message)
     {}
 };
 
@@ -547,7 +535,7 @@ public:
     // IMPLEMENTATION
     //
 private:
-    T* m_ptr{ nullptr };
+    T* m_ptr = nullptr;
 };
 
 
@@ -570,7 +558,7 @@ inline std::vector<wchar_t> BuildMultiString(const std::vector<std::wstring>& da
     }
 
     // Get the total length in wchar_ts of the multi-string
-    size_t totalLen{ 0 };
+    size_t totalLen = 0;
     for (const auto& s : data)
     {
         // Add one to current string's length for the terminating NUL
@@ -581,7 +569,7 @@ inline std::vector<wchar_t> BuildMultiString(const std::vector<std::wstring>& da
     totalLen++;
 
     // Allocate a buffer to store the multi-string
-    std::vector<wchar_t> multiString{};
+    std::vector<wchar_t> multiString;
 
     // Reserve room in the vector to speed up the following insertion loop
     multiString.reserve(totalLen);
@@ -609,7 +597,7 @@ inline std::vector<wchar_t> BuildMultiString(const std::vector<std::wstring>& da
 //------------------------------------------------------------------------------
 
 inline RegKey::RegKey(const HKEY hKey) noexcept
-    : m_hKey{ hKey }
+    : m_hKey(hKey)
 {
 }
 
@@ -627,7 +615,7 @@ inline RegKey::RegKey(const HKEY hKeyParent, const std::wstring& subKey, const R
 
 
 inline RegKey::RegKey(RegKey&& other) noexcept
-    : m_hKey{ other.m_hKey }
+    : m_hKey(other.m_hKey)
 {
     // Other doesn't own the handle anymore
     other.m_hKey = nullptr;
@@ -715,7 +703,7 @@ inline bool RegKey::IsPredefined() const noexcept
 
 inline HKEY RegKey::Detach() noexcept
 {
-    HKEY hKey{ m_hKey };
+    HKEY hKey = m_hKey;
 
     // We don't own the HKEY handle anymore
     m_hKey = nullptr;
@@ -761,7 +749,7 @@ inline void RegKey::Create(
     const REGSAM                desiredAccess
 )
 {
-    constexpr DWORD kDefaultOptions{ REG_OPTION_NON_VOLATILE };
+    const DWORD kDefaultOptions = REG_OPTION_NON_VOLATILE;
 
     Create(hKeyParent, subKey, desiredAccess, kDefaultOptions,
         nullptr, // no security attributes,
@@ -779,7 +767,7 @@ inline void RegKey::Create(
     DWORD* const                disposition
 )
 {
-    HKEY hKey{ nullptr };
+    HKEY hKey = nullptr;
     LONG retCode = ::RegCreateKeyExW(
         hKeyParent,
         subKey.c_str(),
@@ -793,7 +781,7 @@ inline void RegKey::Create(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegCreateKeyEx failed." };
+        throw RegException(retCode, "RegCreateKeyEx failed.");
     }
 
     // Safely close any previously opened key
@@ -810,7 +798,7 @@ inline RegResult RegKey::TryCreate(
     const REGSAM                desiredAccess
 ) noexcept
 {
-    constexpr DWORD kDefaultOptions{ REG_OPTION_NON_VOLATILE };
+    const DWORD kDefaultOptions = REG_OPTION_NON_VOLATILE;
 
     return TryCreate(hKeyParent, subKey, desiredAccess, kDefaultOptions,
         nullptr, // no security attributes,
@@ -828,7 +816,7 @@ inline RegResult RegKey::TryCreate(
     DWORD* const                disposition
 ) noexcept
 {
-    HKEY hKey{ nullptr };
+    HKEY hKey = nullptr;
     RegResult retCode = ::RegCreateKeyExW(
         hKeyParent,
         subKey.c_str(),
@@ -862,7 +850,7 @@ inline void RegKey::Open(
     const REGSAM            desiredAccess
 )
 {
-    HKEY hKey{ nullptr };
+    HKEY hKey = nullptr;
     LONG retCode = ::RegOpenKeyExW(
         hKeyParent,
         subKey.c_str(),
@@ -872,7 +860,7 @@ inline void RegKey::Open(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegOpenKeyExW failed." };
+        throw RegException(retCode, "RegOpenKeyExW failed.");
     }
 
     // Safely close any previously opened key
@@ -889,7 +877,7 @@ inline RegResult RegKey::TryOpen(
     const REGSAM            desiredAccess
 ) noexcept
 {
-    HKEY hKey{ nullptr };
+    HKEY hKey = nullptr;
     RegResult retCode = ::RegOpenKeyExW(
         hKeyParent,
         subKey.c_str(),
@@ -927,7 +915,7 @@ inline void RegKey::SetDwordValue(const std::wstring& valueName, const DWORD dat
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write DWORD value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write DWORD value: RegSetValueExW failed.");
     }
 }
 
@@ -946,7 +934,7 @@ inline void RegKey::SetQwordValue(const std::wstring& valueName, const ULONGLONG
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write QWORD value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write QWORD value: RegSetValueExW failed.");
     }
 }
 
@@ -956,7 +944,7 @@ inline void RegKey::SetStringValue(const std::wstring& valueName, const std::wst
     _ASSERTE(IsValid());
 
     // String size including the terminating NUL, in bytes
-    const DWORD dataSize{ static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t));
 
     LONG retCode = ::RegSetValueExW(
         m_hKey,
@@ -968,7 +956,7 @@ inline void RegKey::SetStringValue(const std::wstring& valueName, const std::wst
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write string value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write string value: RegSetValueExW failed.");
     }
 }
 
@@ -978,7 +966,7 @@ inline void RegKey::SetExpandStringValue(const std::wstring& valueName, const st
     _ASSERTE(IsValid());
 
     // String size including the terminating NUL, in bytes
-    const DWORD dataSize{ static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t));
 
     LONG retCode = ::RegSetValueExW(
         m_hKey,
@@ -990,7 +978,7 @@ inline void RegKey::SetExpandStringValue(const std::wstring& valueName, const st
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write expand string value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write expand string value: RegSetValueExW failed.");
     }
 }
 
@@ -1003,10 +991,10 @@ inline void RegKey::SetMultiStringValue(
     _ASSERTE(IsValid());
 
     // First, we have to build a double-NUL-terminated multi-string from the input data
-    const std::vector<wchar_t> multiString{ details::BuildMultiString(data) };
+    const std::vector<wchar_t> multiString = details::BuildMultiString(data);
 
     // Total size, in bytes, of the whole multi-string structure
-    const DWORD dataSize{ static_cast<DWORD>(multiString.size() * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>(multiString.size() * sizeof(wchar_t));
 
     LONG retCode = ::RegSetValueExW(
         m_hKey,
@@ -1018,7 +1006,7 @@ inline void RegKey::SetMultiStringValue(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write multi-string value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write multi-string value: RegSetValueExW failed.");
     }
 }
 
@@ -1028,7 +1016,7 @@ inline void RegKey::SetBinaryValue(const std::wstring& valueName, const std::vec
     _ASSERTE(IsValid());
 
     // Total data size, in bytes
-    const DWORD dataSize{ static_cast<DWORD>(data.size()) };
+    const DWORD dataSize = static_cast<DWORD>(data.size());
 
     LONG retCode = ::RegSetValueExW(
         m_hKey,
@@ -1040,7 +1028,7 @@ inline void RegKey::SetBinaryValue(const std::wstring& valueName, const std::vec
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write binary data value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write binary data value: RegSetValueExW failed.");
     }
 }
 
@@ -1063,7 +1051,7 @@ inline void RegKey::SetBinaryValue(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot write binary data value: RegSetValueExW failed." };
+        throw RegException(retCode, "Cannot write binary data value: RegSetValueExW failed.");
     }
 }
 
@@ -1109,7 +1097,7 @@ inline RegResult RegKey::TrySetStringValue(
     _ASSERTE(IsValid());
 
     // String size including the terminating NUL, in bytes
-    const DWORD dataSize{ static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t));
 
     return ::RegSetValueExW(
         m_hKey,
@@ -1130,7 +1118,7 @@ inline RegResult RegKey::TrySetExpandStringValue(
     _ASSERTE(IsValid());
 
     // String size including the terminating NUL, in bytes
-    const DWORD dataSize{ static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>((data.length() + 1) * sizeof(wchar_t));
 
     return ::RegSetValueExW(
         m_hKey,
@@ -1158,10 +1146,10 @@ inline RegResult RegKey::TrySetMultiStringValue(
     _ASSERTE(IsValid());
 
     // First, we have to build a double-NUL-terminated multi-string from the input data
-    const std::vector<wchar_t> multiString{ details::BuildMultiString(data) };
+    const std::vector<wchar_t> multiString = details::BuildMultiString(data);
 
     // Total size, in bytes, of the whole multi-string structure
-    const DWORD dataSize{ static_cast<DWORD>(multiString.size() * sizeof(wchar_t)) };
+    const DWORD dataSize = static_cast<DWORD>(multiString.size() * sizeof(wchar_t));
 
     return ::RegSetValueExW(
         m_hKey,
@@ -1182,7 +1170,7 @@ inline RegResult RegKey::TrySetBinaryValue(
     _ASSERTE(IsValid());
 
     // Total data size, in bytes
-    const DWORD dataSize{ static_cast<DWORD>(data.size()) };
+    const DWORD dataSize = static_cast<DWORD>(data.size());
 
     return ::RegSetValueExW(
         m_hKey,
@@ -1218,10 +1206,10 @@ inline DWORD RegKey::GetDwordValue(const std::wstring& valueName) const
 {
     _ASSERTE(IsValid());
 
-    DWORD data{};                   // to be read from the registry
-    DWORD dataSize{ sizeof(data) };  // size of data, in bytes
+    DWORD data = 0;                  // to be read from the registry
+    DWORD dataSize = sizeof(data);   // size of data, in bytes
 
-    const DWORD flags{ RRF_RT_REG_DWORD };
+    const DWORD flags = RRF_RT_REG_DWORD;
     LONG retCode = ::RegGetValueW(
         m_hKey,
         nullptr, // no subkey
@@ -1233,7 +1221,7 @@ inline DWORD RegKey::GetDwordValue(const std::wstring& valueName) const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get DWORD value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get DWORD value: RegGetValueW failed.");
     }
 
     return data;
@@ -1244,8 +1232,8 @@ inline ULONGLONG RegKey::GetQwordValue(const std::wstring& valueName) const
 {
     _ASSERTE(IsValid());
 
-    ULONGLONG data{};                 // to be read from the registry
-    DWORD dataSize{ sizeof(data) };  // size of data, in bytes
+    ULONGLONG data = 0;              // to be read from the registry
+    DWORD dataSize = sizeof(data);   // size of data, in bytes
 
     const DWORD flags = RRF_RT_REG_QWORD;
     LONG retCode = ::RegGetValueW(
@@ -1259,7 +1247,7 @@ inline ULONGLONG RegKey::GetQwordValue(const std::wstring& valueName) const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get QWORD value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get QWORD value: RegGetValueW failed.");
     }
 
     return data;
@@ -1271,8 +1259,8 @@ inline std::wstring RegKey::GetStringValue(const std::wstring& valueName) const
     _ASSERTE(IsValid());
 
     // Get the size of the result string
-    DWORD dataSize{ 0 }; // size of data, in bytes
-    const DWORD flags{ RRF_RT_REG_SZ };
+    DWORD dataSize = 0; // size of data, in bytes
+    const DWORD flags = RRF_RT_REG_SZ;
     LONG retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1284,14 +1272,13 @@ inline std::wstring RegKey::GetStringValue(const std::wstring& valueName) const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get size of string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get size of string value: RegGetValueW failed.");
     }
 
     // Allocate a string of proper size.
     // Note that dataSize is in bytes and includes the terminating NUL;
     // we have to convert the size from bytes to wchar_ts for wstring::resize.
-    std::wstring result{};
-    result.resize(dataSize / sizeof(wchar_t));
+    std::wstring result(dataSize / sizeof(wchar_t), L' ');
 
     // Call RegGetValue for the second time to read the string's content
     retCode = ::RegGetValueW(
@@ -1305,7 +1292,7 @@ inline std::wstring RegKey::GetStringValue(const std::wstring& valueName) const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get string value: RegGetValueW failed.");
     }
 
     // Remove the NUL terminator scribbled by RegGetValue from the wstring
@@ -1322,7 +1309,7 @@ inline std::wstring RegKey::GetExpandStringValue(
 {
     _ASSERTE(IsValid());
 
-    DWORD flags{ RRF_RT_REG_EXPAND_SZ };
+    DWORD flags = RRF_RT_REG_EXPAND_SZ;
 
     // Adjust the flag for RegGetValue considering the expand string option specified by the caller
     if (expandOption == ExpandStringOption::DontExpand)
@@ -1331,7 +1318,7 @@ inline std::wstring RegKey::GetExpandStringValue(
     }
 
     // Get the size of the result string
-    DWORD dataSize{ 0 }; // size of data, in bytes
+    DWORD dataSize = 0; // size of data, in bytes
     LONG retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1343,14 +1330,13 @@ inline std::wstring RegKey::GetExpandStringValue(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get size of expand string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get size of expand string value: RegGetValueW failed.");
     }
 
     // Allocate a string of proper size.
     // Note that dataSize is in bytes and includes the terminating NUL.
     // We must convert from bytes to wchar_ts for wstring::resize.
-    std::wstring result{};
-    result.resize(dataSize / sizeof(wchar_t));
+    std::wstring result(dataSize / sizeof(wchar_t), L' ');
 
     // Call RegGetValue for the second time to read the string's content
     retCode = ::RegGetValueW(
@@ -1364,7 +1350,7 @@ inline std::wstring RegKey::GetExpandStringValue(
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get expand string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get expand string value: RegGetValueW failed.");
     }
 
     // Remove the NUL terminator scribbled by RegGetValue from the wstring
@@ -1379,8 +1365,8 @@ inline std::vector<std::wstring> RegKey::GetMultiStringValue(const std::wstring&
     _ASSERTE(IsValid());
 
     // Request the size of the multi-string, in bytes
-    DWORD dataSize{ 0 };
-    const DWORD flags{ RRF_RT_REG_MULTI_SZ };
+    DWORD dataSize = 0;
+    const DWORD flags = RRF_RT_REG_MULTI_SZ;
     LONG retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1392,14 +1378,13 @@ inline std::vector<std::wstring> RegKey::GetMultiStringValue(const std::wstring&
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get size of multi-string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get size of multi-string value: RegGetValueW failed.");
     }
 
     // Allocate room for the result multi-string.
     // Note that dataSize is in bytes, but our vector<wchar_t>::resize method requires size
     // to be expressed in wchar_ts.
-    std::vector<wchar_t> data{};
-    data.resize(dataSize / sizeof(wchar_t));
+    std::vector<wchar_t> data(dataSize / sizeof(wchar_t), L' ');
 
     // Read the multi-string from the registry into the vector object
     retCode = ::RegGetValueW(
@@ -1413,7 +1398,7 @@ inline std::vector<std::wstring> RegKey::GetMultiStringValue(const std::wstring&
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get multi-string value: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get multi-string value: RegGetValueW failed.");
     }
 
     // Resize vector to the actual size returned by GetRegValue.
@@ -1423,15 +1408,15 @@ inline std::vector<std::wstring> RegKey::GetMultiStringValue(const std::wstring&
 
     // Parse the double-NUL-terminated string into a vector<wstring>,
     // which will be returned to the caller
-    std::vector<std::wstring> result{};
-    const wchar_t* currStringPtr{ &data[0] };
+    std::vector<std::wstring> result;
+    const wchar_t* currStringPtr = &data[0];
     while (*currStringPtr != L'\0')
     {
         // Current string is NUL-terminated, so get its length calling wcslen
-        const size_t currStringLength{ wcslen(currStringPtr) };
+        const size_t currStringLength = wcslen(currStringPtr);
 
         // Add current string to the result vector
-        result.emplace_back( currStringPtr, currStringLength );
+        result.emplace_back(currStringPtr, currStringLength);
 
         // Move to the next string
         currStringPtr += currStringLength + 1;
@@ -1446,8 +1431,8 @@ inline std::vector<BYTE> RegKey::GetBinaryValue(const std::wstring& valueName) c
     _ASSERTE(IsValid());
 
     // Get the size of the binary data
-    DWORD dataSize{ 0 }; // size of data, in bytes
-    const DWORD flags{ RRF_RT_REG_BINARY };
+    DWORD dataSize = 0; // size of data, in bytes
+    const DWORD flags = RRF_RT_REG_BINARY;
     LONG retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1459,11 +1444,11 @@ inline std::vector<BYTE> RegKey::GetBinaryValue(const std::wstring& valueName) c
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get size of binary data: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get size of binary data: RegGetValueW failed.");
     }
 
     // Allocate a buffer of proper size to store the binary data
-    std::vector<BYTE> data( dataSize );
+    std::vector<BYTE> data(dataSize);
 
     // Call RegGetValue for the second time to read the data content
     retCode = ::RegGetValueW(
@@ -1477,7 +1462,7 @@ inline std::vector<BYTE> RegKey::GetBinaryValue(const std::wstring& valueName) c
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get binary data: RegGetValueW failed." };
+        throw RegException(retCode, "Cannot get binary data: RegGetValueW failed.");
     }
 
     return data;
@@ -1493,10 +1478,10 @@ inline RegResult RegKey::TryGetDwordValue(
 
     result = 0;
 
-    DWORD data{};                   // to be read from the registry
-    DWORD dataSize{ sizeof(data) }; // size of data, in bytes
+    DWORD data = 0;                   // to be read from the registry
+    DWORD dataSize = sizeof(data);    // size of data, in bytes
 
-    const DWORD flags{ RRF_RT_REG_DWORD };
+    const DWORD flags = RRF_RT_REG_DWORD;
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr, // no subkey
@@ -1527,10 +1512,10 @@ inline RegResult RegKey::TryGetQwordValue(
 
     result = 0;
 
-    ULONGLONG data{};                 // to be read from the registry
-    DWORD dataSize{ sizeof(data) };   // size of data, in bytes
+    ULONGLONG data = 0;                 // to be read from the registry
+    DWORD dataSize = sizeof(data);      // size of data, in bytes
 
-    const DWORD flags{ RRF_RT_REG_QWORD };
+    const DWORD flags = RRF_RT_REG_QWORD;
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr, // no subkey
@@ -1562,8 +1547,8 @@ inline RegResult RegKey::TryGetStringValue(
     result.clear();
 
     // Get the size of the result string
-    DWORD dataSize{ 0 }; // size of data, in bytes
-    const DWORD flags{ RRF_RT_REG_SZ };
+    DWORD dataSize = 0; // size of data, in bytes
+    const DWORD flags = RRF_RT_REG_SZ;
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr, // no subkey
@@ -1618,7 +1603,7 @@ inline RegResult RegKey::TryGetExpandStringValue(
 
     result.clear();
 
-    DWORD flags{ RRF_RT_REG_EXPAND_SZ };
+    DWORD flags = RRF_RT_REG_EXPAND_SZ;
 
     // Adjust the flag for RegGetValue considering the expand string option specified by the caller
     if (expandOption == ExpandStringOption::DontExpand)
@@ -1627,7 +1612,7 @@ inline RegResult RegKey::TryGetExpandStringValue(
     }
 
     // Get the size of the result string
-    DWORD dataSize{ 0 }; // size of data, in bytes
+    DWORD dataSize = 0; // size of data, in bytes
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1682,8 +1667,8 @@ inline RegResult RegKey::TryGetMultiStringValue(
     result.clear();
 
     // Request the size of the multi-string, in bytes
-    DWORD dataSize{ 0 };
-    const DWORD flags{ RRF_RT_REG_MULTI_SZ };
+    DWORD dataSize = 0;
+    const DWORD flags = RRF_RT_REG_MULTI_SZ;
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1702,8 +1687,7 @@ inline RegResult RegKey::TryGetMultiStringValue(
     // Allocate room for the result multi-string.
     // Note that dataSize is in bytes, but our vector<wchar_t>::resize method requires size
     // to be expressed in wchar_ts.
-    std::vector<wchar_t> data{};
-    data.resize(dataSize / sizeof(wchar_t));
+    std::vector<wchar_t> data(dataSize / sizeof(wchar_t));
 
     // Read the multi-string from the registry into the vector object
     retCode = ::RegGetValueW(
@@ -1730,11 +1714,11 @@ inline RegResult RegKey::TryGetMultiStringValue(
     // Parse the double-NUL-terminated string into a vector<wstring>,
     // which will be returned to the caller
     _ASSERTE(result.empty());
-    const wchar_t* currStringPtr{ &data[0] };
+    const wchar_t* currStringPtr = &data[0];
     while (*currStringPtr != L'\0')
     {
         // Current string is NUL-terminated, so get its length calling wcslen
-        const size_t currStringLength{ wcslen(currStringPtr) };
+        const size_t currStringLength = wcslen(currStringPtr);
 
         // Add current string to the result vector
         result.emplace_back(currStringPtr, currStringLength);
@@ -1758,8 +1742,8 @@ inline RegResult RegKey::TryGetBinaryValue(
     result.clear();
 
     // Get the size of the binary data
-    DWORD dataSize{ 0 }; // size of data, in bytes
-    const DWORD flags{ RRF_RT_REG_BINARY };
+    DWORD dataSize = 0; // size of data, in bytes
+    const DWORD flags = RRF_RT_REG_BINARY;
     RegResult retCode = ::RegGetValueW(
         m_hKey,
         nullptr,    // no subkey
@@ -1803,7 +1787,7 @@ inline DWORD RegKey::QueryValueType(const std::wstring& valueName) const
 {
     _ASSERTE(IsValid());
 
-    DWORD typeId{};     // will be returned by RegQueryValueEx
+    DWORD typeId = 0;     // will be returned by RegQueryValueEx
 
     LONG retCode = ::RegQueryValueExW(
         m_hKey,
@@ -1816,7 +1800,7 @@ inline DWORD RegKey::QueryValueType(const std::wstring& valueName) const
 
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "Cannot get the value type: RegQueryValueExW failed." };
+        throw RegException(retCode, "Cannot get the value type: RegQueryValueExW failed.");
     }
 
     return typeId;
@@ -1829,8 +1813,8 @@ inline std::vector<std::wstring> RegKey::EnumSubKeys() const
 
     // Get some useful enumeration info, like the total number of subkeys
     // and the maximum length of the subkey names
-    DWORD subKeyCount{};
-    DWORD maxSubKeyNameLen{};
+    DWORD subKeyCount = 0;
+    DWORD maxSubKeyNameLen = 0;
     LONG retCode = ::RegQueryInfoKeyW(
         m_hKey,
         nullptr,    // no user-defined class
@@ -1847,9 +1831,9 @@ inline std::vector<std::wstring> RegKey::EnumSubKeys() const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode,
+        throw RegException(retCode,
             "RegQueryInfoKeyW failed while preparing for subkey enumeration."
-        };
+        );
     }
 
     // NOTE: According to the MSDN documentation, the size returned for subkey name max length
@@ -1858,19 +1842,19 @@ inline std::vector<std::wstring> RegKey::EnumSubKeys() const
     maxSubKeyNameLen++;
 
     // Preallocate a buffer for the subkey names
-    auto nameBuffer{ std::make_unique<wchar_t[]>(maxSubKeyNameLen) };
+    auto nameBuffer = std::make_unique<wchar_t[]>(maxSubKeyNameLen);
 
     // The result subkey names will be stored here
-    std::vector<std::wstring> subkeyNames{};
+    std::vector<std::wstring> subkeyNames;
 
     // Reserve room in the vector to speed up the following insertion loop
     subkeyNames.reserve(subKeyCount);
 
     // Enumerate all the subkeys
-    for (DWORD index{ 0 }; index < subKeyCount; index++)
+    for (DWORD index = 0; index < subKeyCount; index++)
     {
         // Get the name of the current subkey
-        DWORD subKeyNameLen{ maxSubKeyNameLen };
+        DWORD subKeyNameLen = maxSubKeyNameLen;
         retCode = ::RegEnumKeyExW(
             m_hKey,
             index,
@@ -1883,7 +1867,7 @@ inline std::vector<std::wstring> RegKey::EnumSubKeys() const
         );
         if (retCode != ERROR_SUCCESS)
         {
-            throw RegException{ retCode, "Cannot enumerate subkeys: RegEnumKeyExW failed." };
+            throw RegException(retCode, "Cannot enumerate subkeys: RegEnumKeyExW failed.");
         }
 
         // On success, the ::RegEnumKeyEx API writes the length of the
@@ -1903,8 +1887,8 @@ inline std::vector<std::pair<std::wstring, DWORD>> RegKey::EnumValues() const
 
     // Get useful enumeration info, like the total number of values
     // and the maximum length of the value names
-    DWORD valueCount{};
-    DWORD maxValueNameLen{};
+    DWORD valueCount = 0;
+    DWORD maxValueNameLen = 0;
     LONG retCode = ::RegQueryInfoKeyW(
         m_hKey,
         nullptr,    // no user-defined class
@@ -1921,10 +1905,10 @@ inline std::vector<std::pair<std::wstring, DWORD>> RegKey::EnumValues() const
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{
+        throw RegException(
             retCode,
             "RegQueryInfoKeyW failed while preparing for value enumeration."
-        };
+        );
     }
 
     // NOTE: According to the MSDN documentation, the size returned for value name max length
@@ -1933,20 +1917,20 @@ inline std::vector<std::pair<std::wstring, DWORD>> RegKey::EnumValues() const
     maxValueNameLen++;
 
     // Preallocate a buffer for the value names
-    auto nameBuffer{ std::make_unique<wchar_t[]>(maxValueNameLen) };
+    auto nameBuffer = std::make_unique<wchar_t[]>(maxValueNameLen);
 
     // The value names and types will be stored here
-    std::vector<std::pair<std::wstring, DWORD>> valueInfo{};
+    std::vector<std::pair<std::wstring, DWORD>> valueInfo;
 
     // Reserve room in the vector to speed up the following insertion loop
     valueInfo.reserve(valueCount);
 
     // Enumerate all the values
-    for (DWORD index{ 0 }; index < valueCount; index++)
+    for (DWORD index = 0; index < valueCount; index++)
     {
         // Get the name and the type of the current value
-        DWORD valueNameLen{ maxValueNameLen };
-        DWORD valueType{};
+        DWORD valueNameLen = maxValueNameLen;
+        DWORD valueType = 0;
         retCode = ::RegEnumValueW(
             m_hKey,
             index,
@@ -1959,7 +1943,7 @@ inline std::vector<std::pair<std::wstring, DWORD>> RegKey::EnumValues() const
         );
         if (retCode != ERROR_SUCCESS)
         {
-            throw RegException{ retCode, "Cannot enumerate values: RegEnumValueW failed." };
+            throw RegException(retCode, "Cannot enumerate values: RegEnumValueW failed.");
         }
 
         // On success, the RegEnumValue API writes the length of the
@@ -1967,7 +1951,7 @@ inline std::vector<std::pair<std::wstring, DWORD>> RegKey::EnumValues() const
         // (not including the terminating NUL).
         // So we can build a wstring based on that.
         valueInfo.emplace_back(
-            std::wstring{ nameBuffer.get(), valueNameLen },
+            std::wstring(nameBuffer.get(), valueNameLen),
             valueType
         );
     }
@@ -1984,8 +1968,8 @@ inline RegResult RegKey::TryEnumSubKeys(std::vector<std::wstring>& subKeys) cons
 
     // Get some useful enumeration info, like the total number of subkeys
     // and the maximum length of the subkey names
-    DWORD subKeyCount{};
-    DWORD maxSubKeyNameLen{};
+    DWORD subKeyCount = 0;
+    DWORD maxSubKeyNameLen = 0;
     RegResult retCode = ::RegQueryInfoKeyW(
         m_hKey,
         nullptr,    // no user-defined class
@@ -2011,7 +1995,7 @@ inline RegResult RegKey::TryEnumSubKeys(std::vector<std::wstring>& subKeys) cons
     maxSubKeyNameLen++;
 
     // Preallocate a buffer for the subkey names
-    auto nameBuffer{ std::make_unique<wchar_t[]>(maxSubKeyNameLen) };
+    auto nameBuffer = std::make_unique<wchar_t[]>(maxSubKeyNameLen);
 
 
     // Should have been cleared at the beginning of the method
@@ -2021,10 +2005,10 @@ inline RegResult RegKey::TryEnumSubKeys(std::vector<std::wstring>& subKeys) cons
     subKeys.reserve(subKeyCount);
 
     // Enumerate all the subkeys
-    for (DWORD index{ 0 }; index < subKeyCount; index++)
+    for (DWORD index = 0; index < subKeyCount; index++)
     {
         // Get the name of the current subkey
-        DWORD subKeyNameLen{ maxSubKeyNameLen };
+        DWORD subKeyNameLen = maxSubKeyNameLen;
         retCode = ::RegEnumKeyExW(
             m_hKey,
             index,
@@ -2060,8 +2044,8 @@ inline RegResult RegKey::TryEnumValues(std::vector<std::pair<std::wstring, DWORD
 
     // Get useful enumeration info, like the total number of values
     // and the maximum length of the value names
-    DWORD valueCount{};
-    DWORD maxValueNameLen{};
+    DWORD valueCount = 0;
+    DWORD maxValueNameLen = 0;
     RegResult retCode = ::RegQueryInfoKeyW(
         m_hKey,
         nullptr,    // no user-defined class
@@ -2087,7 +2071,7 @@ inline RegResult RegKey::TryEnumValues(std::vector<std::pair<std::wstring, DWORD
     maxValueNameLen++;
 
     // Preallocate a buffer for the value names
-    auto nameBuffer{ std::make_unique<wchar_t[]>(maxValueNameLen) };
+    auto nameBuffer = std::make_unique<wchar_t[]>(maxValueNameLen);
 
     // Should have been cleared at the beginning of the method
     _ASSERTE(values.empty());
@@ -2096,11 +2080,11 @@ inline RegResult RegKey::TryEnumValues(std::vector<std::pair<std::wstring, DWORD
     values.reserve(valueCount);
 
     // Enumerate all the values
-    for (DWORD index{ 0 }; index < valueCount; index++)
+    for (DWORD index = 0; index < valueCount; index++)
     {
         // Get the name and the type of the current value
-        DWORD valueNameLen{ maxValueNameLen };
-        DWORD valueType{};
+        DWORD valueNameLen = maxValueNameLen;
+        DWORD valueType = 0;
         retCode = ::RegEnumValueW(
             m_hKey,
             index,
@@ -2122,7 +2106,7 @@ inline RegResult RegKey::TryEnumValues(std::vector<std::pair<std::wstring, DWORD
         // (not including the terminating NUL).
         // So we can build a wstring based on that.
         values.emplace_back(
-            std::wstring{ nameBuffer.get(), valueNameLen },
+            std::wstring(nameBuffer.get(), valueNameLen),
             valueType
         );
     }
@@ -2155,7 +2139,7 @@ inline void RegKey::QueryInfoKey(DWORD& subKeys, DWORD &values, FILETIME& lastWr
     );
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegQueryInfoKeyW failed." };
+        throw RegException(retCode, "RegQueryInfoKeyW failed.");
     }
 }
 
@@ -2216,7 +2200,7 @@ inline void RegKey::DeleteValue(const std::wstring& valueName)
     LONG retCode = ::RegDeleteValueW(m_hKey, valueName.c_str());
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegDeleteValueW failed." };
+        throw RegException(retCode, "RegDeleteValueW failed.");
     }
 }
 
@@ -2228,7 +2212,7 @@ inline void RegKey::DeleteKey(const std::wstring& subKey, const REGSAM desiredAc
     LONG retCode = ::RegDeleteKeyExW(m_hKey, subKey.c_str(), desiredAccess, 0);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegDeleteKeyExW failed." };
+        throw RegException(retCode, "RegDeleteKeyExW failed.");
     }
 }
 
@@ -2240,7 +2224,7 @@ inline void RegKey::DeleteTree(const std::wstring& subKey)
     LONG retCode = ::RegDeleteTreeW(m_hKey, subKey.c_str());
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegDeleteTreeW failed." };
+        throw RegException(retCode, "RegDeleteTreeW failed.");
     }
 }
 
@@ -2252,7 +2236,7 @@ inline void RegKey::CopyTree(const std::wstring& sourceSubKey, const RegKey& des
     LONG retCode = ::RegCopyTreeW(m_hKey, sourceSubKey.c_str(), destKey.Get());
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegCopyTreeW failed." };
+        throw RegException(retCode, "RegCopyTreeW failed.");
     }
 }
 
@@ -2264,7 +2248,7 @@ inline void RegKey::FlushKey()
     LONG retCode = ::RegFlushKey(m_hKey);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegFlushKey failed." };
+        throw RegException(retCode, "RegFlushKey failed.");
     }
 }
 
@@ -2276,7 +2260,7 @@ inline void RegKey::LoadKey(const std::wstring& subKey, const std::wstring& file
     LONG retCode = ::RegLoadKeyW(m_hKey, subKey.c_str(), filename.c_str());
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegLoadKeyW failed." };
+        throw RegException(retCode, "RegLoadKeyW failed.");
     }
 }
 
@@ -2291,7 +2275,7 @@ inline void RegKey::SaveKey(
     LONG retCode = ::RegSaveKeyW(m_hKey, filename.c_str(), securityAttributes);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegSaveKeyW failed." };
+        throw RegException(retCode, "RegSaveKeyW failed.");
     }
 }
 
@@ -2301,7 +2285,7 @@ inline void RegKey::EnableReflectionKey()
     LONG retCode = ::RegEnableReflectionKey(m_hKey);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegEnableReflectionKey failed." };
+        throw RegException(retCode, "RegEnableReflectionKey failed.");
     }
 }
 
@@ -2311,18 +2295,18 @@ inline void RegKey::DisableReflectionKey()
     LONG retCode = ::RegDisableReflectionKey(m_hKey);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegDisableReflectionKey failed." };
+        throw RegException(retCode, "RegDisableReflectionKey failed.");
     }
 }
 
 
 inline bool RegKey::QueryReflectionKey() const
 {
-    BOOL isReflectionDisabled{ FALSE };
+    BOOL isReflectionDisabled = FALSE;
     LONG retCode = ::RegQueryReflectionKey(m_hKey, &isReflectionDisabled);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegQueryReflectionKey failed." };
+        throw RegException(retCode, "RegQueryReflectionKey failed.");
     }
 
     return (isReflectionDisabled ? true : false);
@@ -2334,11 +2318,11 @@ inline void RegKey::ConnectRegistry(const std::wstring& machineName, const HKEY 
     // Safely close any previously opened key
     Close();
 
-    HKEY hKeyResult{ nullptr };
+    HKEY hKeyResult = nullptr;
     LONG retCode = ::RegConnectRegistryW(machineName.c_str(), hKeyPredefined, &hKeyResult);
     if (retCode != ERROR_SUCCESS)
     {
-        throw RegException{ retCode, "RegConnectRegistryW failed." };
+        throw RegException(retCode, "RegConnectRegistryW failed.");
     }
 
     // Take ownership of the result key
@@ -2425,7 +2409,7 @@ inline RegResult RegKey::TryDisableReflectionKey() noexcept
 
 inline RegResult RegKey::TryQueryReflectionKey(bool& reflectionDisabled) const noexcept
 {
-    BOOL isReflectionDisabled{ FALSE };
+    BOOL isReflectionDisabled = FALSE;
     RegResult retCode = ::RegQueryReflectionKey(m_hKey, &isReflectionDisabled);
     if (retCode.Failed())
     {
@@ -2447,7 +2431,7 @@ inline RegResult RegKey::TryConnectRegistry(
     // Safely close any previously opened key
     Close();
 
-    HKEY hKeyResult{ nullptr };
+    HKEY hKeyResult = nullptr;
     RegResult retCode = ::RegConnectRegistryW(machineName.c_str(), hKeyPredefined, &hKeyResult);
     if (retCode.Failed())
     {
@@ -2482,10 +2466,45 @@ inline std::wstring RegKey::RegTypeToString(const DWORD regType)
 //                          RegResult Inline Methods
 //------------------------------------------------------------------------------
 
-inline std::wstring RegResult::ErrorMessage(DWORD languageId) const
+inline RegResult::RegResult(const LONG result) noexcept
+    : m_result(result)
+{}
+
+
+inline bool RegResult::IsOk() const noexcept
+{
+    return m_result == ERROR_SUCCESS;
+}
+
+
+inline bool RegResult::Failed() const noexcept
+{
+    return m_result != ERROR_SUCCESS;
+}
+
+
+inline RegResult::operator bool() const noexcept
+{
+    return IsOk();
+}
+
+
+inline LONG RegResult::Code() const noexcept
+{
+    return m_result;
+}
+
+
+inline std::wstring RegResult::ErrorMessage() const
+{
+    return ErrorMessage(MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT));
+}
+
+
+inline std::wstring RegResult::ErrorMessage(const DWORD languageId) const
 {
     // Invoke FormatMessage() to retrieve the error message from Windows
-    details::ScopedLocalFree<wchar_t> messagePtr{};
+    details::ScopedLocalFree<wchar_t> messagePtr;
     DWORD retCode = ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
         FORMAT_MESSAGE_FROM_SYSTEM |
         FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -2498,12 +2517,12 @@ inline std::wstring RegResult::ErrorMessage(DWORD languageId) const
     if (retCode == 0)
     {
         // FormatMessage failed: return an empty string
-        return std::wstring{};
+        return std::wstring();
     }
 
     // Safely copy the C-string returned by FormatMessage() into a std::wstring object,
     // and return it back to the caller.
-    return std::wstring{ messagePtr.Get() };
+    return std::wstring(messagePtr.Get());
 }
 
 

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -38,10 +38,10 @@ void Test()
     // Test subkey and value enumeration
     //
 
-    const wstring testSubKey{ L"SOFTWARE\\GioTest" };
-    RegKey key{ HKEY_CURRENT_USER, testSubKey };
+    const wstring testSubKey = L"SOFTWARE\\GioTest";
+    RegKey key(HKEY_CURRENT_USER, testSubKey);
 
-    vector<wstring> subKeyNames{ key.EnumSubKeys() };
+    vector<wstring> subKeyNames = key.EnumSubKeys();
     wcout << L"Subkeys:\n";
     for (const auto& s : subKeyNames)
     {
@@ -49,7 +49,7 @@ void Test()
     }
     wcout << L'\n';
 
-    vector<pair<wstring, DWORD>> values{ key.EnumValues() };
+    vector<pair<wstring, DWORD>> values = key.EnumValues();
     wcout << L"Values:\n";
     for (const auto& v : values)
     {
@@ -66,12 +66,12 @@ void Test()
 
     key.Open(HKEY_CURRENT_USER, testSubKey);
 
-    const DWORD testDw{ 0x1234ABCD };
-    const ULONGLONG testQw{ 0xAABBCCDD11223344 };
-    const wstring testSz{ L"CiaoTestSz" };
-    const wstring testExpandSz{ L"%PATH%" };
-    const vector<BYTE> testBinary{ 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33 };
-    const vector<wstring> testMultiSz{ L"Hi", L"Hello", L"Ciao" };
+    const DWORD testDw = 0x1234ABCD;
+    const ULONGLONG testQw = 0xAABBCCDD11223344;
+    const wstring testSz = L"CiaoTestSz";
+    const wstring testExpandSz = L"%PATH%";
+    const vector<BYTE> testBinary = { 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33 };
+    const vector<wstring> testMultiSz = { L"Hi", L"Hello", L"Ciao" };
 
     key.SetDwordValue(L"TestValueDword", testDw);
     key.SetQwordValue(L"TestValueQword", testQw);
@@ -171,7 +171,7 @@ static inline void Check(const RegResult& retCode, const char* const message)
 {
     if (retCode.Failed())
     {
-        throw RegException{ retCode.Code(), message };
+        throw RegException(retCode.Code(), message);
     }
 }
 
@@ -185,12 +185,12 @@ void TestTryMethods()
     // Test subkey and value enumeration
     //
 
-    const wstring testSubKey{ L"SOFTWARE\\GioTest" };
-    RegKey key{};
+    const wstring testSubKey = L"SOFTWARE\\GioTest";
+    RegKey key;
     RegResult retCode = key.TryOpen(HKEY_CURRENT_USER, testSubKey);
     Check(retCode, "RegKey::TryOpen failed.");
 
-    vector<wstring> subKeyNames{};
+    vector<wstring> subKeyNames;
     retCode = key.TryEnumSubKeys(subKeyNames);
     Check(retCode, "RegKey::TryEnumSubKeys failed.");
 
@@ -201,7 +201,7 @@ void TestTryMethods()
     }
     wcout << L'\n';
 
-    vector<pair<wstring, DWORD>> values{};
+    vector<pair<wstring, DWORD>> values;
     retCode = key.TryEnumValues(values);
     Check(retCode, "RegKey::TryEnumValues failed.");
 
@@ -222,12 +222,12 @@ void TestTryMethods()
     retCode = key.TryOpen(HKEY_CURRENT_USER, testSubKey);
     Check(retCode, "RegKey::TryOpen failed.");
 
-    const DWORD testDw{ 0x1234ABCD };
-    const ULONGLONG testQw{ 0xAABBCCDD11223344 };
-    const wstring testSz{ L"CiaoTestSz" };
-    const wstring testExpandSz{ L"%PATH%" };
-    const vector<BYTE> testBinary{ 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33 };
-    const vector<wstring> testMultiSz{ L"Hi", L"Hello", L"Ciao" };
+    const DWORD testDw = 0x1234ABCD;
+    const ULONGLONG testQw = 0xAABBCCDD11223344;
+    const wstring testSz = L"CiaoTestSz";
+    const wstring testExpandSz = L"%PATH%";
+    const vector<BYTE> testBinary = { 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33 };
+    const vector<wstring> testMultiSz = { L"Hi", L"Hello", L"Ciao" };
 
     retCode = key.TrySetDwordValue(L"TestValueDword", testDw);
     Check(retCode, "RegKey::TrySetDwordValue failed.");
@@ -248,7 +248,7 @@ void TestTryMethods()
     Check(retCode, "RegKey::TrySetBinaryValue failed.");
 
 
-    DWORD testDw1{};
+    DWORD testDw1 = 0;
     retCode = key.TryGetDwordValue(L"TestValueDword", testDw1);
     Check(retCode, "RegKey::TryGetDwordValue failed.");
     if (testDw1 != testDw)
@@ -256,7 +256,7 @@ void TestTryMethods()
         wcout << L"RegKey::TryGetDwordValue failed.\n";
     }
 
-    DWORD typeId{};
+    DWORD typeId = 0;
     retCode = key.TryQueryValueType(L"TestValueDword", typeId);
     Check(retCode, "RegKey::TryQueryValueType failed.");
     if (typeId != REG_DWORD)
@@ -264,7 +264,7 @@ void TestTryMethods()
         wcout << L"RegKey::TryQueryValueType failed for REG_DWORD.\n";
     }
 
-    ULONGLONG testQw1{};
+    ULONGLONG testQw1 = 0;
     retCode = key.TryGetQwordValue(L"TestValueQword", testQw1);
     Check(retCode, "RegKey::TryGetQwordValue failed.");
     if (testQw1 != testQw)
@@ -355,8 +355,8 @@ void TestTryMethods()
 
 int main()
 {
-    constexpr int kExitOk = 0;
-    constexpr int kExitError = 1;
+    const int kExitOk = 0;
+    const int kExitError = 1;
 
     try
     {


### PR DESCRIPTION
I find the "classical" C++ (C-like) initialization style much clearer and more readable than "uniform" initialization.

In other words, I prefer:

```
int n = 64;
std::string computer = "C64";
std::vector<int> v = {1, 2, 3};
for (int i = 0; i < N; i++)
```
to:

```
int n{64};
std::string computer{"C64"};
std::vector<int> v{1, 2, 3};
for (int i{0}; i < N; i++)
```