### PR TITLE
Added more non-throwing TryXxx methods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 by Giovanni Dicanio
+Copyright (c) 2017-2022 by Giovanni Dicanio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v4.1.2
+# WinReg v5.0.0
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio
@@ -103,6 +103,10 @@ else
 }
 ```
 
+Note that many methods are available in _two forms_: one that _throws an exception_ of type `RegException` on error (e.g. `RegKey::Open`),
+and another that _returns an error status object_ of type `RegResult` (e.g. `RegKey::TryOpen`) instead of throwing an exception.
+In addition, as indicated above, some methods like the `RegKey::TryGet...Value` ones return `std::optional` instead of throwing exceptions;
+in case of errors, the returned `std::optional` _does not contain_ any value.
 
 You can take a look at the test code in `WinRegTest.cpp` for some sample usage.
 

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -29,7 +29,9 @@ using winreg::RegKey;
 using winreg::RegException;
 
 
+//
 // Test common RegKey methods
+//
 void Test()
 {
     wcout << "\n *** Testing Common RegKey Methods *** \n\n";


### PR DESCRIPTION
There are many requests of methods that signal error conditions without throwing an exception, but for example returning a std::optional that does not contain any value: I added several of those, using the TryXxx naming convention.
Moreover, I refined and improved the public interface of some existing methods, like QueryInfoKey.