### PR TITLE
Replace std::optional<T> with RegExpected<T> in TryGetXxxValue Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ wstring s  = key.GetStringValue(L"SomeStringValue");
 You can also open a registry key using a two-step construction process:
 
 ```c++
-RegKey key{};
+RegKey key;
 key.Open(HKEY_CURRENT_USER, L"SOFTWARE\\SomeKey");
 ```
 
@@ -100,18 +100,19 @@ for (const auto & v : values)
 ```
 
 In addition, you can also use the `RegKey::TryGet...Value` methods, that return `RegExpected<T>` 
-instead of throwing on errors:
+instead of throwing an exception on error:
 
 ```c++
 // RegKey::TryGetDwordValue() returns a RegExpected<DWORD>;
 // the returned RegExpected contains a RegResult instance on error.
 
-if (auto dw = key.TryGetDwordValue(L"SomeDwordValue"))
+const auto res = key.TryGetDwordValue(L"SomeDwordValue");
+if (res.IsValid())  // or simply:  if (res)
 {
     //
     // All right: Process the returned value ...
     //
-    // Use dw.GetValue() to access the stored DWORD.
+    // Use res.GetValue() to access the stored DWORD.
     //
 }
 else
@@ -120,7 +121,7 @@ else
     // The method has failed: 
     //
     // The returned RegExpected contains a RegResult with an error code.
-    // Use dw.GetError() to access the RegResult object.
+    // Use res.GetError() to access the RegResult object.
     //
 }
 ```

--- a/WinReg/WinReg.vcxproj.user
+++ b/WinReg/WinReg.vcxproj.user
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/WinReg/WinReg.vcxproj.user
+++ b/WinReg/WinReg.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -19,7 +19,6 @@
 #include <vector>
 
 
-using std::optional;
 using std::pair;
 using std::vector;
 using std::wcout;
@@ -27,6 +26,7 @@ using std::wstring;
 
 using winreg::RegKey;
 using winreg::RegException;
+using winreg::RegExpected;
 
 
 //
@@ -129,14 +129,14 @@ void Test()
 
     if (auto testDw2 = key.TryGetDwordValue(L"TestTryValueDword"))
     {
-        if (testDw2 != testDw)
+        if (testDw2.GetValue() != testDw)
         {
             wcout << L"RegKey::TryGetDwordValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetDwordValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetDwordValue failed.\n";
     }
 
     DWORD typeId = key.QueryValueType(L"TestValueDword");
@@ -153,14 +153,14 @@ void Test()
 
     if (auto testQw2 = key.TryGetQwordValue(L"TestTryValueQword"))
     {
-        if (testQw2 != testQw)
+        if (testQw2.GetValue() != testQw)
         {
             wcout << L"RegKey::TryGetQwordValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetQwordValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetQwordValue failed.\n";
     }
 
     typeId = key.QueryValueType(L"TestValueQword");
@@ -177,14 +177,14 @@ void Test()
 
     if (auto testSz2 = key.TryGetStringValue(L"TestTryValueString"))
     {
-        if (testSz2 != testSz)
+        if (testSz2.GetValue() != testSz)
         {
             wcout << L"RegKey::TryGetStringValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetStringValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetStringValue failed.\n";
     }
 
     typeId = key.QueryValueType(L"TestValueString");
@@ -201,14 +201,14 @@ void Test()
 
     if (auto testExpandSz2 = key.TryGetExpandStringValue(L"TestTryValueExpandString"))
     {
-        if (testExpandSz2 != testExpandSz)
+        if (testExpandSz2.GetValue() != testExpandSz)
         {
             wcout << L"RegKey::TryGetExpandStringValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetExpandStringValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetExpandStringValue failed.\n";
     }
 
     typeId = key.QueryValueType(L"TestValueExpandString");
@@ -225,14 +225,14 @@ void Test()
 
     if (auto testMultiSz2 = key.TryGetMultiStringValue(L"TestTryValueMultiString"))
     {
-        if (testMultiSz2 != testMultiSz)
+        if (testMultiSz2.GetValue() != testMultiSz)
         {
             wcout << L"RegKey::TryGetMultiStringValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetMultiStringValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetMultiStringValue failed.\n";
     }
 
     typeId = key.QueryValueType(L"TestValueMultiString");
@@ -249,14 +249,14 @@ void Test()
 
     if (auto testBinary2 = key.TryGetBinaryValue(L"TestTryValueBinary"))
     {
-        if (testBinary2 != testBinary)
+        if (testBinary2.GetValue() != testBinary)
         {
             wcout << L"RegKey::TryGetBinaryValue failed.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetBinaryValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetBinaryValue failed.\n";
     }
 
     typeId = key.QueryValueType(L"TestValueBinary");
@@ -274,14 +274,14 @@ void Test()
 
     if (auto testEmptyBinary2 = key.TryGetBinaryValue(L"TestTryEmptyBinary"))
     {
-        if (testEmptyBinary2 != testEmptyBinary)
+        if (testEmptyBinary2.GetValue() != testEmptyBinary)
         {
             wcout << L"RegKey::TryGetBinaryValue failed with zero-length binary data.\n";
         }
     }
     else
     {
-        wcout << L"RegKey::TryGetBinaryValue failed (std::optional has no value).\n";
+        wcout << L"RegKey::TryGetBinaryValue failed.\n";
     }
 
 


### PR DESCRIPTION
`std::optional<T>` looses the information about the error code; to keep that information, I defined a custom `RegExpected<T>` class, which is returned in place of `std::optional` from the non-throwing TryGetXxxValue methods.