### PR TITLE
Handle race condition of destination buffer length change between RegGetValue calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v6.1.1
+# WinReg v6.2.0
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio


### PR DESCRIPTION
Before this change, to get values of types like strings, multi-strings or binary data, two successive calls were made to the RegGetValue Windows Registry API. The first call was made to get the destination buffer size; then a buffer of that size was allocated to read the actual data; and, finally, a second call to RegGetValue was made to read the data in the previously allocated buffer. 
Schematically:

1. Invoke RegGetValue the get the output buffer size
2. Allocate a buffer of that size
3. Invoke RegGetValue again to read the data from the registry in the above output buffer

The **race condition** that may happen (but has never happened during my use of the library) is a modification of the registry value between the two calls to RegGetValue, such that the buffer size is not large enough to store the new data. To prevent this situation, a while loop is used instead. For example, in RegKey::GetStringValue, I wrote some new code like this:

```c++
  LSTATUS retCode = ERROR_MORE_DATA;
  while (retCode == ERROR_MORE_DATA)
  {
      // Get the size of the result string
      retCode = ::RegGetValueW( ... );

      // Check for error...

      // Allocate a string of proper size
      result.resize(dataSize / sizeof(wchar_t));

      // Call RegGetValue for the second time to read the string's content
      retCode = ::RegGetValueW( ... );
  }
```
