### PR TITLE
Added methods to check if a key contains values and subkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v6.2.0
+# WinReg v6.3.0
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio
@@ -113,6 +113,17 @@ for (const auto & [valueName, valueType] : values)
     //
     // Use valueName and valueType
     //
+    ...
+}
+```
+
+You can also check if a key contains a given value or even a subkey, invoking the
+`RegKey::ContainsValue` and `RegKey::ContainsSubKey` methods, e.g.:
+
+```c++
+if (key.ContainsValue(L"Connie"))
+{
+    // The key contains the value named "Connie"
     ...
 }
 ```

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -286,6 +286,39 @@ void Test()
 
 
     //
+    // Test the ContainsValue and ContainsSubKey methods
+    //
+
+    // Test the ContainsValue method with a value that exists
+    bool valueIsPresent = key.ContainsValue(L"TestValueDword");
+    if (valueIsPresent == false)
+    {
+        wcout << L"RegKey::ContainsValue failed to check an existing value.\n";
+    }
+
+    // Test the ContainsValue method with a value that does not exist
+    valueIsPresent = key.ContainsValue(L"Value_That_Does_NOT_Exist");
+    if (valueIsPresent == true)
+    {
+        wcout << L"RegKey::ContainsValue failed to check a non-existing value.\n";
+    }
+
+    // Test the ContainsSubKey method with a subkey that exists
+    bool subKeyIsPresent = key.ContainsSubKey(L"SubKey1");
+    if (subKeyIsPresent == false)
+    {
+        wcout << L"RegKey::ContainsSubKey failed to check an existing subkey.\n";
+    }
+
+    // Test the ContainsSubKey method with a subkey that does not exist
+    subKeyIsPresent = key.ContainsSubKey(L"SubKey_That_Does_NOT_Exist");
+    if (subKeyIsPresent == true)
+    {
+        wcout << L"RegKey::ContainsSubKey failed to check a non-existing subkey.\n";
+    }
+
+
+    //
     // Remove some test values
     //
 


### PR DESCRIPTION
Added new methods to the `RegKey` class, to check if a key contains some specific values or subkeys:

- `RegKey::ContainsValue`
- `RegKey::ContainsSubKey`

and the corresponding TryXxxx versions:

- `RegKey::TryContainsValue`
- `RegKey::TryContainsSubKey`
