### PR TITLE
Added checks when casting from size_t to DWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v6.3.0
+# WinReg v6.3.1
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio


### PR DESCRIPTION
Throw exceptions in case of `size_t` not fitting a `DWORD` (possible in 64-bit builds with MSVC `size_t` being 64-bit and `DWORD` 32-bit).