### PR TITLE
Add methods to read raw binary data

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2024 by Giovanni Dicanio
+Copyright (c) 2017-2025 by Giovanni Dicanio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WinReg v6.3.2
+# WinReg v6.4.0
 ## High-level C++ Wrapper Around the Low-level Windows Registry C-interface API
 
 by Giovanni Dicanio
@@ -29,10 +29,10 @@ The Win32 registry value types are mapped to C++ higher-level types according th
 | `REG_MULTI_SZ`       | `std::vector<std::wstring>`  |
 | `REG_BINARY`         | `std::vector<BYTE>`          |
 
-
 This code is currently developed using **Visual Studio 2019** with **C++17** features enabled 
 (`/std:c++17`). I have no longer tested the code with previous compilers. 
 The code compiles cleanly at warning level 4 (`/W4`) in both 32-bit and 64-bit builds.
+Moreover, the code compiles cleanly also in C++20 mode (`/std:c++20`).
 
 This is a **header-only** library, implemented in the **[`WinReg.hpp`](WinReg/WinReg.hpp)** 
 header file.
@@ -158,6 +158,11 @@ else
     //
 }
 ```
+
+The library also supports reading raw binary data for Registry types that are unsupported
+or less documented (e.g. `REG_RESOURCE_LIST`, `REG_FULL_RESOURCE_DESCRIPTOR`, etc.),
+via the `RegKey::GetRawValue` and `RegKey::TryGetRawValue` methods.
+
 
 **Version Note**: WinReg v5.1.1 is the latest version in which the `TryGetXxxValue` methods return 
 `std::optional<T>` (discarding the information about the error code).

--- a/WinReg/WinReg.hpp
+++ b/WinReg/WinReg.hpp
@@ -9,7 +9,7 @@
 //               Copyright (C) by Giovanni Dicanio
 //
 // First version: 2017, January 22nd
-// Last update:   2024, November 6th
+// Last update:   2025, August 10th
 //
 // E-mail: <first name>.<last name> AT REMOVE_THIS gmail.com
 //
@@ -34,7 +34,8 @@
 //
 // Compiler: Visual Studio 2019
 // C++ Language Standard: C++17 (/std:c++17)
-// Code compiles cleanly at warning level 4 (/W4) on both 32-bit and 64-bit builds.
+// Code compiles cleanly at warning level 4 (/W4) on both 32-bit and 64-bit builds,
+// also in C++20 mode (/std:c++20).
 //
 // Requires building in Unicode mode (which has been the default since VS2005).
 //
@@ -42,7 +43,7 @@
 //
 // The MIT License(MIT)
 //
-// Copyright(c) 2017-2024 by Giovanni Dicanio
+// Copyright(c) 2017-2025 by Giovanni Dicanio
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files(the "Software"), to deal
@@ -344,6 +345,19 @@ public:
     [[nodiscard]] std::vector<std::wstring> GetMultiStringValue(const std::wstring& valueName) const;
     [[nodiscard]] std::vector<BYTE> GetBinaryValue(const std::wstring& valueName) const;
 
+    // GetRawValue is very similar to GetBinaryValue, except that here in the "raw" version
+    // I do *not* use the RRF_RT_REG_BINARY flag with the ::RegGetValueW API for type checking.
+    // In this way, the type is *not* restricted to REG_BINARY, and this GetRawValue method
+    // can be invoked to retrieve binary data for unsupported or less documented types like
+    // REG_RESOURCE_LIST, REG_FULL_RESOURCE_DESCRIPTOR, REG_LINK, etc.
+    //
+    // This addition came from an issue opened on this code on GitHub:
+    //
+    // No way to get the value of a REG_RESOURCE_LIST key and some others
+    // https://github.com/GiovanniDicanio/WinReg/issues/77
+    //
+    [[nodiscard]] std::vector<BYTE> GetRawValue(const std::wstring& valueName) const;
+
 
     //
     // Registry Value Getters Returning RegExpected<T>
@@ -364,6 +378,12 @@ public:
 
     [[nodiscard]] RegExpected<std::vector<BYTE>>
             TryGetBinaryValue(const std::wstring& valueName) const;
+
+    // Similar to TryGetBinaryValue, but without type restriction to REG_BINARY.
+    // Can be used to retrieve raw binary data for other types like REG_RESOURCE_LIST, etc.
+    // Please read the comment to the GetRawValue method to learn more.
+    [[nodiscard]] RegExpected<std::vector<BYTE>>
+            TryGetRawValue(const std::wstring& valueName) const;
 
 
     //
@@ -1887,6 +1907,76 @@ inline std::vector<BYTE> RegKey::GetBinaryValue(const std::wstring& valueName) c
 }
 
 
+inline std::vector<BYTE> RegKey::GetRawValue(const std::wstring& valueName) const
+{
+    _ASSERTE(IsValid());
+
+    // Room for the binary data, to be read from the registry
+    std::vector<BYTE> binaryData;
+
+    // Size of binary data, in bytes
+    DWORD dataSize = 0;
+
+    // No type restriction, so this method can be used to read raw binary data
+    // for unsupported or less documented types like REG_RESOURCE_LIST,
+    // REG_FULL_RESOURCE_DESCRIPTOR, REG_LINK, etc.
+    constexpr DWORD flags = RRF_RT_ANY;
+
+    LSTATUS retCode = ERROR_MORE_DATA;
+
+    while (retCode == ERROR_MORE_DATA)
+    {
+        // Request the size of the binary data, in bytes
+        retCode = ::RegGetValueW(
+            m_hKey,
+            nullptr,    // no subkey
+            valueName.c_str(),
+            flags,
+            nullptr,    // type not required
+            nullptr,    // output buffer not needed now
+            &dataSize
+        );
+        if (retCode != ERROR_SUCCESS)
+        {
+            throw RegException{ retCode,
+                                "Cannot get the size of the raw binary data: RegGetValueW failed." };
+        }
+
+        // Allocate a buffer of proper size to store the binary data
+        binaryData.resize(dataSize);
+
+        // Handle the special case of zero-length binary data:
+        // If the binary data value in the registry is empty, just return an empty vector.
+        if (dataSize == 0)
+        {
+            _ASSERTE(binaryData.empty());
+            return binaryData;
+        }
+
+        // Call RegGetValue for the second time to read the binary data content into the vector
+        retCode = ::RegGetValueW(
+            m_hKey,
+            nullptr,            // no subkey
+            valueName.c_str(),
+            flags,
+            nullptr,            // type not required
+            binaryData.data(),  // output buffer
+            &dataSize
+        );
+    }
+
+    if (retCode != ERROR_SUCCESS)
+    {
+        throw RegException{ retCode, "Cannot get the raw binary data: RegGetValueW failed." };
+    }
+
+    // Resize vector to the actual size returned by the last call to RegGetValue
+    binaryData.resize(dataSize);
+
+    return binaryData;
+}
+
+
 inline RegExpected<DWORD> RegKey::TryGetDwordValue(const std::wstring& valueName) const
 {
     _ASSERTE(IsValid());
@@ -2145,6 +2235,77 @@ inline RegExpected<std::vector<BYTE>>
     using RegValueType = std::vector<BYTE>;
 
     constexpr DWORD flags = RRF_RT_REG_BINARY;
+
+    // Room for the binary data
+    std::vector<BYTE> data;
+
+    DWORD dataSize = 0; // size of binary data, in bytes
+
+    LSTATUS retCode = ERROR_MORE_DATA;
+
+    while (retCode == ERROR_MORE_DATA)
+    {
+        // Request the size of the binary data, in bytes
+        retCode = ::RegGetValueW(
+            m_hKey,
+            nullptr,    // no subkey
+            valueName.c_str(),
+            flags,
+            nullptr,    // type not required
+            nullptr,    // output buffer not needed now
+            &dataSize
+        );
+        if (retCode != ERROR_SUCCESS)
+        {
+            return details::MakeRegExpectedWithError<RegValueType>(retCode);
+        }
+
+        // Allocate a buffer of proper size to store the binary data
+        data.resize(dataSize);
+
+        // Handle the special case of zero-length binary data:
+        // If the binary data value in the registry is empty, just return
+        if (dataSize == 0)
+        {
+            _ASSERTE(data.empty());
+            return RegExpected<RegValueType>{ data };
+        }
+
+        // Call RegGetValue for the second time to read the binary data content into the vector
+        retCode = ::RegGetValueW(
+            m_hKey,
+            nullptr,        // no subkey
+            valueName.c_str(),
+            flags,
+            nullptr,        // type not required
+            data.data(),    // output buffer
+            &dataSize
+        );
+    }
+
+    if (retCode != ERROR_SUCCESS)
+    {
+        return details::MakeRegExpectedWithError<RegValueType>(retCode);
+    }
+
+    // Resize vector to the actual size returned by the last call to RegGetValue
+    data.resize(dataSize);
+
+    return RegExpected<RegValueType>{ data };
+}
+
+
+inline RegExpected<std::vector<BYTE>>
+    RegKey::TryGetRawValue(const std::wstring& valueName) const
+{
+    _ASSERTE(IsValid());
+
+    using RegValueType = std::vector<BYTE>;
+
+    // No type restriction, so this method can be used to read raw binary data
+    // for unsupported or less documented types like REG_RESOURCE_LIST,
+    // REG_FULL_RESOURCE_DESCRIPTOR, REG_LINK, etc.
+    constexpr DWORD flags = RRF_RT_ANY;
 
     // Room for the binary data
     std::vector<BYTE> data;

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -285,7 +285,60 @@ void Test()
     }
 
 
-    // TODO: May add some tests for the GetRawValue and TryGetRawValue methods.
+    //////////////////////////////////////////////////////////////////////////
+    //
+    // Test the RegKey::GetRawValue and RegKey::TryGetRawValue methods
+    // on the same binary data used for the above RegKey::GetBinaryValue
+    // and RegKey::TryGetBinaryValue methods.
+    //
+    // TODO:
+    // May add more tests for the RegKey::GetRawValue and RegKey::TryGetRawValue
+    // methods, for example trying to read data of different types
+    // from the Registry.
+    // The key point of these "Get RAW Value" methods is that they *ignore*
+    // the data *type*, and just read *raw* binary data from the Registry,
+    // independently from the type.
+    //
+
+    vector<BYTE> testRawBinary1 = key.GetRawValue(L"TestValueBinary");
+    if (testRawBinary1 != testBinary)
+    {
+        wcout << L"RegKey::GetRawValue failed.\n";
+    }
+
+    if (auto testRawBinary2 = key.TryGetRawValue(L"TestTryValueBinary"))
+    {
+        if (testRawBinary2.GetValue() != testBinary)
+        {
+            wcout << L"RegKey::TryGetRawValue failed.\n";
+        }
+    }
+    else
+    {
+        wcout << L"RegKey::TryGetRawValue failed.\n";
+    }
+
+    // Test the special case of zero-length binary array
+    vector<BYTE> testEmptyRawBinary1 = key.GetRawValue(L"TestEmptyBinary");
+    if (testEmptyRawBinary1 != testEmptyBinary)
+    {
+        wcout << L"RegKey::GetRawValue failed with zero-length binary data.\n";
+    }
+
+    if (auto testEmptyRawBinary2 = key.TryGetRawValue(L"TestTryEmptyBinary"))
+    {
+        if (testEmptyRawBinary2.GetValue() != testEmptyBinary)
+        {
+            wcout << L"RegKey::TryGetRawValue failed with zero-length binary data.\n";
+        }
+    }
+    else
+    {
+        wcout << L"RegKey::TryGetRawValue failed.\n";
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+
 
 
     //

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -285,6 +285,9 @@ void Test()
     }
 
 
+    // TODO: May add some tests for the GetRawValue and TryGetRawValue methods.
+
+
     //
     // Test the ContainsValue and ContainsSubKey methods
     //


### PR DESCRIPTION
Add two new methods `RegKey::GetRawValue` and `RegKey::TryGetRawValue`, to read raw binary data without type restriction, as per issue #77 .