### PR TITLE
Bug-fixes and small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,7 @@ comments and suggestions.
 - Use the more specific `winreg_internal` name for private/internal namespace, instead of the more general `details` 
   (which is safer and more robust in case of clients doing `using namespace winreg;`).
 - Fixed bugs of `RegKey::LoadKey/TryLoadKey` failing because the handle is nulled-before-use via `Close` call.
-- Fixed zero-length `REG_SZ/REG_EXPAND_SZ` values crashing `RegKey`'s methods `GetStringValue`, `GetExpandStringValue`, 
-  `TryGetStringValue`, `TryGetExpandStringValue` (explicitly added an `if (dataSize == 0) ...` check).
 - Fixed `RegKey` move-assignment implementation (removed bogus extra condition `... && (m_hKey != other.m_hKey)`).
-- In case of zero-byte `REG_MULTI_SZ`, `RegKey::GetMultiStringValue` and `RegKey::TryGetMultiStringValue` 
-  will now return an empty vector instead of throwing `RegException{ERROR_INVALID_DATA, "Not a double-null terminated string."}`
-  when calling the `ParseMultiString` helper function.
 - Added a comment note clarifying a potential TOCTOU race condition inherent to the Win32 registry enumeration API 
   and the `RegKey` enumeration methods `EnumSubKeys/EnumValues/TryEnumSubKeys/TryEnumValues`.
 

--- a/WinReg/WinReg.hpp
+++ b/WinReg/WinReg.hpp
@@ -845,20 +845,9 @@ private:
 // returns a vector of wstrings that represent the single strings.
 //
 // Also supports embedded empty strings in the sequence.
-//
-// NOTE: If the input vector is empty, returns an *empty* vector<wstring>,
-// instead of throwing an exception of type RegException with ERROR_INVALID_DATA
-// error code.
 //------------------------------------------------------------------------------
 [[nodiscard]] inline std::vector<std::wstring> ParseMultiString(const std::vector<wchar_t>& data)
 {
-    // Check the special case of empty input vector
-    if (data.empty())
-    {
-        // Just return an empty vector as result
-        return std::vector<std::wstring>{};
-    }
-
     // Make sure that there are two terminating L'\0's at the end of the sequence
     if (!IsDoubleNullTerminated(data))
     {
@@ -1734,15 +1723,8 @@ inline std::wstring RegKey::GetStringValue(const std::wstring& valueName) const
         throw RegException{ retCode, "Cannot get the string value: RegGetValueW failed." };
     }
 
-    if (dataSize == 0)
-    {
-        result.clear();
-    }
-    else
-    {
-        // Remove the NUL terminator scribbled by RegGetValue from the wstring
-        result.resize((dataSize / sizeof(wchar_t)) - 1);
-    }
+    // Remove the NUL terminator scribbled by RegGetValue from the wstring
+    result.resize((dataSize / sizeof(wchar_t)) - 1);
 
     return result;
 }
@@ -1810,15 +1792,8 @@ inline std::wstring RegKey::GetExpandStringValue(
         throw RegException{ retCode, "Cannot get the expand string value: RegGetValueW failed." };
     }
 
-    if (dataSize == 0)
-    {
-        result.clear();
-    }
-    else
-    {
-        // Remove the NUL terminator scribbled by RegGetValue from the wstring
-        result.resize((dataSize / sizeof(wchar_t)) - 1);
-    }
+    // Remove the NUL terminator scribbled by RegGetValue from the wstring
+    result.resize((dataSize / sizeof(wchar_t)) - 1);
 
     return result;
 }
@@ -2135,16 +2110,8 @@ inline RegExpected<std::wstring> RegKey::TryGetStringValue(const std::wstring& v
         return winreg_internal::MakeRegExpectedWithError<RegValueType>(retCode);
     }
 
-
-    if (dataSize == 0)
-    {
-        result.clear();
-    }
-    else
-    {
-        // Remove the NUL terminator scribbled by RegGetValue from the wstring
-        result.resize((dataSize / sizeof(wchar_t)) - 1);
-    }
+    // Remove the NUL terminator scribbled by RegGetValue from the wstring
+    result.resize((dataSize / sizeof(wchar_t)) - 1);
 
     return RegExpected<RegValueType>{ result };
 }
@@ -2210,15 +2177,8 @@ inline RegExpected<std::wstring> RegKey::TryGetExpandStringValue(
         return winreg_internal::MakeRegExpectedWithError<RegValueType>(retCode);
     }
 
-    if (dataSize == 0)
-    {
-        result.clear();
-    }
-    else
-    {
-        // Remove the NUL terminator scribbled by RegGetValue from the wstring
-        result.resize((dataSize / sizeof(wchar_t)) - 1);
-    }
+    // Remove the NUL terminator scribbled by RegGetValue from the wstring
+    result.resize((dataSize / sizeof(wchar_t)) - 1);
 
     return RegExpected<RegValueType>{ result };
 }

--- a/WinReg/WinRegTest.cpp
+++ b/WinReg/WinRegTest.cpp
@@ -374,6 +374,7 @@ void Test()
     }
 
 
+
     //
     // Remove some test values
     //


### PR DESCRIPTION
## Improvements in v6.5.0

- Upgraded IDE from Visual Studio 2019 to Visual Studio 2022.
- Use the more specific `winreg_internal` name for private/internal namespace, instead of the more general `details` 
  (which is safer and more robust in case of clients doing `using namespace winreg;`).
- Fixed bugs of `RegKey::LoadKey/TryLoadKey` failing because the handle is nulled-before-use via `Close` call.
- Fixed `RegKey` move-assignment implementation (removed bogus extra condition `... && (m_hKey != other.m_hKey)`).
- Added a comment note clarifying a potential TOCTOU race condition inherent to the Win32 registry enumeration API 
  and the `RegKey` enumeration methods `EnumSubKeys/EnumValues/TryEnumSubKeys/TryEnumValues`.